### PR TITLE
[15.0][IMP] default doc template for replacement

### DIFF
--- a/frappe_etax_service/models/account_move.py
+++ b/frappe_etax_service/models/account_move.py
@@ -28,6 +28,7 @@ class AccountMove(models.Model):
             "target": "new",
             "context": {
                 "default_etax_move_type": self.etax_move_type,
+                "default_doc_name_template": self.doc_name_template.id,
             },
         }
 
@@ -103,6 +104,7 @@ class AccountMove(models.Model):
         res[0]["payment_reference"] = self.payment_reference
         res[0]["invoice_date"] = self.invoice_date
         res[0]["invoice_date_due"] = self.invoice_date_due
+        res[0]["doc_name_template"] = self.doc_name_template.id
         move = self.create(res[0])
         self.button_draft()
         self.button_cancel()

--- a/frappe_etax_service/models/etax_th.py
+++ b/frappe_etax_service/models/etax_th.py
@@ -71,6 +71,11 @@ class ETaxTH(models.AbstractModel):
     is_send_frappe = fields.Boolean(
         copy=False,
     )
+    doc_name_template = fields.Many2one(
+        string="Invoice template",
+        comodel_name="doc.type",
+        copy=False,
+    )
 
     def sign_etax(self, form_type=False, form_name=False):
         self._pre_validation(form_type, form_name)

--- a/frappe_etax_service/views/account_move_views.xml
+++ b/frappe_etax_service/views/account_move_views.xml
@@ -66,6 +66,7 @@
                             <field
                                 name="etax_transaction_code"
                                 string="Transaction code"
+                                invisible="1"
                                 readonly="1"
                                 force_save="1"
                             />
@@ -95,6 +96,12 @@
                                 name="create_purpose"
                                 attrs="{'required': [('replaced_entry_id', '!=', False)]}"
                             />
+                            <!-- User may get mixed up with this. -->
+                            <!-- <field
+                                name="doc_name_template"
+                                options="{'no_open': True}"
+                                attrs="{'invisible': [('doc_name_template', '=', False)]}"
+                            /> -->
                         </group>
                     </group>
                 </page>

--- a/frappe_etax_service/wizards/wizard_select_etax_doctype.py
+++ b/frappe_etax_service/wizards/wizard_select_etax_doctype.py
@@ -26,6 +26,7 @@ class WizardSelectEtaxDoctype(models.TransientModel):
         invoice.update(
             {
                 "etax_doctype": self.doc_name_template.doctype_code,
+                "doc_name_template": self.doc_name_template,
                 "is_send_frappe": True,
             }
         )


### PR DESCRIPTION
In case of Replacement Invoice, after click e-Tax Invoice button on the field invoice template will be default following previous invoice

![Screenshot from 2023-10-24 10-05-54](https://github.com/ecosoft-odoo/ecosoft-addons/assets/96042966/04741274-7064-4b9a-9017-f307ae479d9a)
