### PR TITLE
Improved code in account_move_reconcile_no_cancel module

### DIFF
--- a/account_move_reconcile_no_cancel/models/account_move.py
+++ b/account_move_reconcile_no_cancel/models/account_move.py
@@ -8,38 +8,33 @@ from odoo.exceptions import ValidationError
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def _get_receivable_payable_lines(self):
-        return self.line_ids.filtered(
-            lambda l: l.account_internal_type in ["receivable", "payable"],
-        )
-
     def _check_fiscalyear_lock_date(self):
         if self._context.get("bypass_lockdate"):
             return True
         return super()._check_fiscalyear_lock_date()
 
-    def button_draft(self):
+    def _check_move_reconciled(self, action=""):
         for rec in self:
-            rec_pay_lines = rec._get_receivable_payable_lines()
-            # Expense case journal only (not include payment)
-            sheet = rec.line_ids.mapped("expense_id").mapped("sheet_id")
-            sheet_not_post = sheet.filtered(lambda l: l.state != "post")
-            if (
-                rec.move_type in ["in_invoice", "out_invoice"]
-                and (
-                    rec_pay_lines.matched_debit_ids or rec_pay_lines.matched_credit_ids
-                )
-            ) or (sheet and sheet_not_post and not rec.payment_id):
-                raise ValidationError(
-                    _("You cannot reset to draft reconciled entries.")
-                )
+            matched_debit_credit_ids = rec.line_ids.mapped(
+                "matched_debit_ids"
+            ) | rec.line_ids.mapped("matched_credit_ids")
+            if matched_debit_credit_ids:
+                # Check reconciled from invoice and expense's move (not included payment)
+                sheet = rec.line_ids.mapped("expense_id.sheet_id")
+                if rec.move_type in [
+                    "{}_{}".format(x, y)
+                    for x in ["in", "out"]
+                    for y in ["invoice", "refund"]
+                ] or (sheet and not rec.payment_id):
+                    raise ValidationError(
+                        _("You cannot {} reconciled entries.").format(action)
+                    )
+        return True
+
+    def button_draft(self):
+        self._check_move_reconciled(action="reset to draft")
         return super().button_draft()
 
     def button_cancel(self):
-        for rec in self:
-            rec_pay_lines = rec._get_receivable_payable_lines()
-            if rec.move_type in ["in_invoice", "out_invoice"] and (
-                rec_pay_lines.matched_debit_ids or rec_pay_lines.matched_credit_ids
-            ):
-                raise ValidationError(_("You cannot cancel reconciled entries."))
+        self._check_move_reconciled(action="cancel")
         return super().button_cancel()

--- a/account_move_reconcile_no_cancel/wizard/account_move_reversal.py
+++ b/account_move_reconcile_no_cancel/wizard/account_move_reversal.py
@@ -1,8 +1,7 @@
 # Copyright 2023 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, models
-from odoo.exceptions import ValidationError
+from odoo import models
 
 
 class AccountMoveReversal(models.TransientModel):
@@ -11,20 +10,7 @@ class AccountMoveReversal(models.TransientModel):
     def reverse_moves(self):
         self.ensure_one()
         moves = self.move_ids
-        for rec in moves:
-            # Expense case journal only (not include payment)
-            sheet = rec.line_ids.mapped("expense_id").mapped("sheet_id")
-            sheet_not_post = sheet.filtered(lambda l: l.state != "post")
-            rec_pay_lines = rec._get_receivable_payable_lines()
-            if (
-                rec.move_type in ["in_invoice", "out_invoice"]
-                and (
-                    rec_pay_lines.matched_debit_ids or rec_pay_lines.matched_credit_ids
-                )
-            ) or (sheet and sheet_not_post and not rec.payment_id):
-                raise ValidationError(
-                    _("You cannot reset to draft / reverse reconciled entries.")
-                )
+        moves._check_move_reconciled(action="reset to draft / reverse")
         res = super().reverse_moves()
         # Overwite payment state to reversed
         moves.with_context(bypass_lockdate=1).write({"payment_state": "reversed"})


### PR DESCRIPTION
Not allowed cancel / reset to draft move from invoice and expense (except payment or create move directly)

Could you please review ? @Saran440 