### PR TITLE
[FIX] account_financial_report_extension: sorted code, name before group

### DIFF
--- a/account_financial_report_extension/report/trial_balance.py
+++ b/account_financial_report_extension/report/trial_balance.py
@@ -16,10 +16,14 @@ class TrialBalanceReport(models.AbstractModel):
             # Mapping report data
             trial_balance = res_data["trial_balance"]
             trial_balance = map_type._get_report_data_mapping_afr(trial_balance)
+            # Sorting trial balance by code, name before grouping
+            trial_balance_sorted = sorted(
+                trial_balance, key=lambda x: (x["code"], x["name"])
+            )
             # Summary data mapping
             result = []
             for key, group in itertools.groupby(
-                trial_balance, key=lambda x: (x["code"], x["name"])
+                trial_balance_sorted, key=lambda x: (x["code"], x["name"])
             ):
                 group = list(group)
                 # Get sum groupby name, code


### PR DESCRIPTION
Step to test:
1. create GFMIS with random lines (no sequence)
2. print trail balance with data maping
3. some account will duplicate (not grouping)

This PR fixes by sorted name, code before group