### PR TITLE
[15.0][IMP] usability_webhooks: use parameter 'search_key' to search record

### DIFF
--- a/usability_webhooks/README.rst
+++ b/usability_webhooks/README.rst
@@ -70,7 +70,8 @@ Following successful authentication, you can proceed with five API routes:
                "payload": {
                   "field1": "value1",
                   ...
-               }
+               },
+               "result_field": ["field1", ...]  # optional
             }
          }
       }
@@ -85,9 +86,14 @@ Following successful authentication, you can proceed with five API routes:
          "params": {
             "model": "<model name>",
             "vals": {
-               "<unique key>": "value",  # can be ID or name search string
-               "field1": "value1",
-               ...
+               "search_key": {
+                  "<key_field>": "value",  # can be ID or name search string
+               },
+               "payload": {
+                  "field1": "value1",
+                  ...
+               },
+               "result_field": ["field1", ...]  # optional
             }
          }
       }
@@ -101,8 +107,10 @@ Following successful authentication, you can proceed with five API routes:
          "params": {
             "model": "<model name>",
             "vals": {
+               "search_key": {
+                  "<key_field>": "value",  # can be ID or name search string
+               },
                "payload": {
-                  "<unique key>": "value",  # can be ID or name search string
                   "field1": "value1",
                   ...
                }
@@ -142,8 +150,10 @@ Following successful authentication, you can proceed with five API routes:
          "params": {
             "model": "<model name>",
             "vals": {
+               "search_key": {
+                  "<key_field>": "value",  # can be ID or name search string
+               },
                "payload": {
-                  "name": "<name>",
                   "method": "<method>",
                   "parameter": {"<key>": "<value>", ...}
                }

--- a/usability_webhooks/controllers/utils.py
+++ b/usability_webhooks/controllers/utils.py
@@ -15,17 +15,6 @@ class WebhookUtils(models.AbstractModel):
     _name = "webhook.utils"
     _description = "Utils Class"
 
-    @tools.ormcache("model")
-    def _search_key(self, model):
-        """Return the unique search key for each model, else use 'name'"""
-        keys = {
-            "product.template": "default_code",
-            "product.product": "default_code",
-            "res.partner": "ref",
-        }
-        key = keys.get(model, "name")
-        return key
-
     @tools.ormcache("model", "val")
     def _call_name_search_cache(self, model, val, args=None):
         args = args or []
@@ -203,13 +192,28 @@ class WebhookUtils(models.AbstractModel):
         rec.clear_caches()
         return res
 
+    def _search_object(self, model, vals):
+        search_key = vals.get("search_key", {})
+        search_domain = [(k, "=", v) for k, v in search_key.items()]
+
+        # Prepare Header Dict (non o2m)
+        if not search_key:
+            raise ValidationError(_("Parameter 'search_key' in 'vals' not found!"))
+
+        # search record to update
+        rec = self.env[model].search(search_domain)
+        return rec
+
     @api.model
-    def friendly_update_data(self, model, vals, key_field):
+    def friendly_update_data(self, model, vals):
         """Accept friendly data_dict in following format to update existing rec
         This method, will always delete o2m lines and recreate it.
         -------------------------------------------------------------
         vals:
         {
+            'search_key': {
+                "<key_field>": "<key_value>",
+            },
             'payload': {
                 'field1': value1,
                 'field2_id': value2,  # can be ID or name search string
@@ -228,37 +232,25 @@ class WebhookUtils(models.AbstractModel):
                 # 'field4_id': [{'name': 'some name', ...}, {...}, {...}]
             }
         },
-        key_field: search_key  # i.e., name, ref, code, etc.
         """
         data_dict = vals.get("payload", {})
         auto_create = vals.get("auto_create", {})
-        res = {}
-        ctx_line = self._get_ctx_lines()
-        # Prepare Header Dict (non o2m)
-        if not key_field or key_field not in data_dict:
-            raise ValidationError(_("Method update_data() key_field is not valid!"))
-        rec = self.env[model].search(
-            [
-                (key_field, "=", data_dict[key_field]),
-                (
-                    "company_id",
-                    "=",
-                    data_dict.get("company_id", self.env.company_id.id),
-                ),
-            ]
-        )
-        if not rec:
+        search_key = vals.get("search_key", {})
+
+        rec = self._search_object(model, vals)
+
+        if len(rec) > 1:
             raise ValidationError(
-                _("Search key '%(key_field)s' not found!")
-                % {"key_field": data_dict[key_field]}
+                _(
+                    "Search key '%(key_field)s' in model '%(model)s' found mutiple matches!"
+                )
+                % {"key_field": search_key, "model": model}
             )
-        elif len(rec) > 1:
-            raise ValidationError(
-                _("Search key '%(key_field)s' found mutiple matches!")
-                % {"key_field": data_dict[key_field]}
-            )
+
         rec_fields = []
         line_all_fields = []
+        ctx_line = self._get_ctx_lines()
+
         for field, model_field in rec._fields.items():
             if field in data_dict and model_field.type != "one2many":
                 rec_fields.append(field)
@@ -503,18 +495,20 @@ class WebhookUtils(models.AbstractModel):
         if res["is_success"]:
             res_id = res["result"]["id"]
             p = self.env[model].browse(res_id)
-            res["result"][self._search_key(model)] = p[self._search_key(model)]
+            result_field = vals.get("result_field", [])
+            for result in result_field:
+                res["result"][result] = p[result]
         _logger.info("[{}].create_data(), output: {}".format(model, res))
         return res
 
     @api.model
     def update_data(self, model, vals):
         _logger.info("[{}].update_data(), input: {}".format(model, vals))
-        res = self.friendly_update_data(model, vals, self._search_key(model))
+        res = self.friendly_update_data(model, vals)
         if res["is_success"]:
-            res_id = res["result"]["id"]
-            p = self.env[model].browse(res_id)
-            res["result"][self._search_key(model)] = p[self._search_key(model)]
+            search_key = vals.get("search_key", {})
+            for key, value in search_key.items():
+                res["result"][key] = value
         _logger.info("[{}].update_data(), output: {}".format(model, res))
         return res
 
@@ -522,14 +516,14 @@ class WebhookUtils(models.AbstractModel):
     def create_update_data(self, model, vals):
         _logger.info("[{}].create_update_data(), input: {}".format(model, vals))
         # Update
-        search_value = vals["payload"].get(self._search_key(model))
-        if not self.env[model].search([(self._search_key(model), "=", search_value)]):
+        rec = self._search_object(model, vals)
+        if not rec:
             return self.create_data(model, vals)  # fall back to create
-        res = self.friendly_update_data(model, vals, self._search_key(model))
+        res = self.friendly_update_data(model, vals)
         if res["is_success"]:
-            res_id = res["result"]["id"]
-            p = self.env[model].browse(res_id)
-            res["result"][self._search_key(model)] = p[self._search_key(model)]
+            search_key = vals.get("search_key", {})
+            for key, value in search_key.items():
+                res["result"][key] = value
         _logger.info("[{}].create_update_data(), output: {}".format(model, res))
         return res
 
@@ -611,11 +605,14 @@ class WebhookUtils(models.AbstractModel):
     def call_function(self, model, vals):
         """
         Call a function on a model object based on the provided input.
-        Parameters:
-        - name (str): The name of the model to perform the function on.
-        - method (str): The name of the function to call.
-        - parameter (dict):
-            A dictionary containing the arguments to pass to the function. (if any)
+        Parameters (search_key) are used to search for the record:
+            - search_key: A dictionary containing the search criteria to find the record.
+
+        Parameters (payload) are used to call the function:
+            - method (str): The name of the function to call.
+            - parameter (dict):
+                A dictionary containing the arguments to pass to the function. (if any)
+
         ==================================
         Example Format for Call Function:
         ==================================
@@ -623,8 +620,10 @@ class WebhookUtils(models.AbstractModel):
             "params": {
                 "model": "account.move",  # Model to call
                 "vals": {
+                    "search_key": {
+                        "name": "INV/2021/0001"
+                    },
                     "payload": {
-                        "name": "INV/2021/0001",
                         "method": "action_post",
                         # Optional, see the function definition for required parameters
                         "parameter": {},
@@ -635,9 +634,10 @@ class WebhookUtils(models.AbstractModel):
         """
         _logger.info("[{}].call_function(), input: {}".format(model, vals))
         data_dict = vals.get("payload", {})
-        key = self._search_key(model)
-        obj = self.env[model].search([(key, "=", data_dict.get(key))])
-        res = getattr(obj, data_dict["method"])(**dict(data_dict.get("parameter")))
+        parameter = data_dict.get("parameter", {})
+
+        rec = self._search_object(model, vals)
+        res = getattr(rec, data_dict["method"])(**dict(parameter) if parameter else {})
         return {
             "is_success": True,
             "result": res,

--- a/usability_webhooks/readme/USAGE.rst
+++ b/usability_webhooks/readme/USAGE.rst
@@ -30,7 +30,8 @@ Following successful authentication, you can proceed with five API routes:
                "payload": {
                   "field1": "value1",
                   ...
-               }
+               },
+               "result_field": ["field1", ...]  # optional
             }
          }
       }
@@ -45,9 +46,14 @@ Following successful authentication, you can proceed with five API routes:
          "params": {
             "model": "<model name>",
             "vals": {
-               "<unique key>": "value",  # can be ID or name search string
-               "field1": "value1",
-               ...
+               "search_key": {
+                  "<key_field>": "value",  # can be ID or name search string
+               },
+               "payload": {
+                  "field1": "value1",
+                  ...
+               },
+               "result_field": ["field1", ...]  # optional
             }
          }
       }
@@ -61,8 +67,10 @@ Following successful authentication, you can proceed with five API routes:
          "params": {
             "model": "<model name>",
             "vals": {
+               "search_key": {
+                  "<key_field>": "value",  # can be ID or name search string
+               },
                "payload": {
-                  "<unique key>": "value",  # can be ID or name search string
                   "field1": "value1",
                   ...
                }
@@ -102,8 +110,10 @@ Following successful authentication, you can proceed with five API routes:
          "params": {
             "model": "<model name>",
             "vals": {
+               "search_key": {
+                  "<key_field>": "value",  # can be ID or name search string
+               },
                "payload": {
-                  "name": "<name>",
                   "method": "<method>",
                   "parameter": {"<key>": "<value>", ...}
                }

--- a/usability_webhooks/static/description/index.html
+++ b/usability_webhooks/static/description/index.html
@@ -419,7 +419,8 @@ The format for creating data should be in the following structure:</p>
 </span>         <span class="s2">&quot;payload&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
 </span>            <span class="s2">&quot;field1&quot;</span><span class="p">:</span> <span class="s2">&quot;value1&quot;</span><span class="p">,</span><span class="w">
 </span>            <span class="o">...</span><span class="w">
-</span>         <span class="p">}</span><span class="w">
+</span>         <span class="p">},</span><span class="w">
+</span>         <span class="s2">&quot;result_field&quot;</span><span class="p">:</span> <span class="p">[</span><span class="s2">&quot;field1&quot;</span><span class="p">,</span> <span class="o">...</span><span class="p">]</span>  <span class="c1"># optional</span><span class="w">
 </span>      <span class="p">}</span><span class="w">
 </span>   <span class="p">}</span><span class="w">
 </span><span class="p">}</span>
@@ -433,9 +434,14 @@ The format follows that of <tt class="docutils literal">create_data</tt>, but it
 </span>   <span class="s2">&quot;params&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
 </span>      <span class="s2">&quot;model&quot;</span><span class="p">:</span> <span class="s2">&quot;&lt;model name&gt;&quot;</span><span class="p">,</span><span class="w">
 </span>      <span class="s2">&quot;vals&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
-</span>         <span class="s2">&quot;&lt;unique key&gt;&quot;</span><span class="p">:</span> <span class="s2">&quot;value&quot;</span><span class="p">,</span>  <span class="c1"># can be ID or name search string</span><span class="w">
-</span>         <span class="s2">&quot;field1&quot;</span><span class="p">:</span> <span class="s2">&quot;value1&quot;</span><span class="p">,</span><span class="w">
-</span>         <span class="o">...</span><span class="w">
+</span>         <span class="s2">&quot;search_key&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
+</span>            <span class="s2">&quot;&lt;key_field&gt;&quot;</span><span class="p">:</span> <span class="s2">&quot;value&quot;</span><span class="p">,</span>  <span class="c1"># can be ID or name search string</span><span class="w">
+</span>         <span class="p">},</span><span class="w">
+</span>         <span class="s2">&quot;payload&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
+</span>            <span class="s2">&quot;field1&quot;</span><span class="p">:</span> <span class="s2">&quot;value1&quot;</span><span class="p">,</span><span class="w">
+</span>            <span class="o">...</span><span class="w">
+</span>         <span class="p">},</span><span class="w">
+</span>         <span class="s2">&quot;result_field&quot;</span><span class="p">:</span> <span class="p">[</span><span class="s2">&quot;field1&quot;</span><span class="p">,</span> <span class="o">...</span><span class="p">]</span>  <span class="c1"># optional</span><span class="w">
 </span>      <span class="p">}</span><span class="w">
 </span>   <span class="p">}</span><span class="w">
 </span><span class="p">}</span>
@@ -448,8 +454,10 @@ using a unique key in the field to find the desired data and update values in th
 </span>   <span class="s2">&quot;params&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
 </span>      <span class="s2">&quot;model&quot;</span><span class="p">:</span> <span class="s2">&quot;&lt;model name&gt;&quot;</span><span class="p">,</span><span class="w">
 </span>      <span class="s2">&quot;vals&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
+</span>         <span class="s2">&quot;search_key&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
+</span>            <span class="s2">&quot;&lt;key_field&gt;&quot;</span><span class="p">:</span> <span class="s2">&quot;value&quot;</span><span class="p">,</span>  <span class="c1"># can be ID or name search string</span><span class="w">
+</span>         <span class="p">},</span><span class="w">
 </span>         <span class="s2">&quot;payload&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
-</span>            <span class="s2">&quot;&lt;unique key&gt;&quot;</span><span class="p">:</span> <span class="s2">&quot;value&quot;</span><span class="p">,</span>  <span class="c1"># can be ID or name search string</span><span class="w">
 </span>            <span class="s2">&quot;field1&quot;</span><span class="p">:</span> <span class="s2">&quot;value1&quot;</span><span class="p">,</span><span class="w">
 </span>            <span class="o">...</span><span class="w">
 </span>         <span class="p">}</span><span class="w">
@@ -491,8 +499,10 @@ by using a search domain to find the desired recordset. You can also limit and o
 </span>   <span class="s2">&quot;params&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
 </span>      <span class="s2">&quot;model&quot;</span><span class="p">:</span> <span class="s2">&quot;&lt;model name&gt;&quot;</span><span class="p">,</span><span class="w">
 </span>      <span class="s2">&quot;vals&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
+</span>         <span class="s2">&quot;search_key&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
+</span>            <span class="s2">&quot;&lt;key_field&gt;&quot;</span><span class="p">:</span> <span class="s2">&quot;value&quot;</span><span class="p">,</span>  <span class="c1"># can be ID or name search string</span><span class="w">
+</span>         <span class="p">},</span><span class="w">
 </span>         <span class="s2">&quot;payload&quot;</span><span class="p">:</span> <span class="p">{</span><span class="w">
-</span>            <span class="s2">&quot;name&quot;</span><span class="p">:</span> <span class="s2">&quot;&lt;name&gt;&quot;</span><span class="p">,</span><span class="w">
 </span>            <span class="s2">&quot;method&quot;</span><span class="p">:</span> <span class="s2">&quot;&lt;method&gt;&quot;</span><span class="p">,</span><span class="w">
 </span>            <span class="s2">&quot;parameter&quot;</span><span class="p">:</span> <span class="p">{</span><span class="s2">&quot;&lt;key&gt;&quot;</span><span class="p">:</span> <span class="s2">&quot;&lt;value&gt;&quot;</span><span class="p">,</span> <span class="o">...</span><span class="p">}</span><span class="w">
 </span>         <span class="p">}</span><span class="w">


### PR DESCRIPTION
This PR is implement `usability_webhooks` to flexible, user can add field that would like to show or search by yourself

**create_data**

```
{
   "params": {
      "model": "<model name>",
      "vals": {
         "payload": {
            "field1": "value1",
            ...
         },
         "result_field": ["field1", ...]  # optional
      }
   }
}
```

**create_update_data**

```
{
   "params": {
      "model": "<model name>",
      "vals": {
         "search_key": {
            "<key_field>": "value",  # can be ID or name search string
         },
         "payload": {
            "field1": "value1",
            ...
         },
         "result_field": ["field1", ...]  # optional
      }
   }
}
```

**update_data**
```
{
   "params": {
      "model": "<model name>",
      "vals": {
         "search_key": {
            "<key_field>": "value",  # can be ID or name search string
         },
         "payload": {
            "field1": "value1",
            ...
         }
      }
   }
}
```

**call_function**
```
{
   "params": {
      "model": "<model name>",
      "vals": {
         "search_key": {
            "<key_field>": "value",  # can be ID or name search string
         },
         "payload": {
            "method": "<method>",
            "parameter": {"<key>": "<value>", ...}
         }
      }
   }
}
```
