### PR TITLE
[ADD] Create replacement etax receipt

### DIFF
--- a/frappe_etax_service/__manifest__.py
+++ b/frappe_etax_service/__manifest__.py
@@ -15,6 +15,7 @@
         "security/ir.model.access.csv",
         "data/purpose_code_data.xml",
         "data/cron.xml",
+        "data/server_action.xml",
         "wizards/wizard_select_etax_doctype_view.xml",
         "wizards/account_move_reversal_view.xml",
         "wizards/account_debit_note_view.xml",

--- a/frappe_etax_service/data/server_action.xml
+++ b/frappe_etax_service/data/server_action.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="action_create_replacement" model="ir.actions.server">
+        <field name="name">Update Tax Invoice number</field>
+        <field name="model_id" ref="account.model_account_payment"/>
+        <field name="state">code</field>
+        <field name="code">
+if record.tax_invoice_ids:
+    if not record.tax_invoice_ids.mapped('tax_invoice_number'):
+        record.tax_invoice_ids.write({
+            'tax_invoice_number': record.name,
+            'tax_invoice_date': record.date
+        })
+        </field>
+    </record>
+</odoo>

--- a/frappe_etax_service/data/server_action.xml
+++ b/frappe_etax_service/data/server_action.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="action_create_replacement" model="ir.actions.server">
         <field name="name">Update Tax Invoice number</field>
-        <field name="model_id" ref="account.model_account_payment"/>
+        <field name="model_id" ref="account.model_account_payment" />
         <field name="state">code</field>
         <field name="code">
 if record.tax_invoice_ids:

--- a/frappe_etax_service/models/account_move.py
+++ b/frappe_etax_service/models/account_move.py
@@ -21,14 +21,14 @@ class AccountMove(models.Model):
     def action_open_replacement_wizard(self):
         self.ensure_one()
         return {
-            'type': 'ir.actions.act_window',
-            'name': 'Create Replacement',
-            'res_model': 'wizard.select.replacement.purpose',
-            'view_mode': 'form',
-            'target': 'new',
-            'context': {
-                'default_res_model': self._name,
-            }
+            "type": "ir.actions.act_window",
+            "name": "Create Replacement",
+            "res_model": "wizard.select.replacement.purpose",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_res_model": self._name,
+            },
         }
 
     def _get_branch_id(self):

--- a/frappe_etax_service/models/account_move.py
+++ b/frappe_etax_service/models/account_move.py
@@ -18,6 +18,19 @@ class AccountMove(models.Model):
     #         "target": "new",
     #     }
 
+    def action_open_replacement_wizard(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Create Replacement',
+            'res_model': 'wizard.select.replacement.purpose',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {
+                'default_res_model': self._name,
+            }
+        }
+
     def _get_branch_id(self):
         """
         By default, core odoo do not provide branch_id field in
@@ -86,12 +99,6 @@ class AccountMove(models.Model):
             }
         ).copy_data()
         old_number = self.name
-        suffix = "-R"
-        if suffix in old_number:
-            [number, rev] = old_number.split(suffix)
-            res[0]["name"] = f"{number}{suffix}{int(rev) + 1}"
-        else:
-            res[0]["name"] = f"{old_number}{suffix}{1}"
         res[0]["posted_before"] = self.posted_before
         res[0]["payment_reference"] = self.payment_reference
         res[0]["invoice_date"] = self.invoice_date

--- a/frappe_etax_service/models/account_payment.py
+++ b/frappe_etax_service/models/account_payment.py
@@ -9,7 +9,6 @@ class AccountPayment(models.Model):
     _inherit = ["account.payment", "etax.th"]
 
     has_create_replacement = fields.Boolean(
-        string="Has Create Replacement",
         copy=False,
         default=False,
     )

--- a/frappe_etax_service/models/account_payment.py
+++ b/frappe_etax_service/models/account_payment.py
@@ -1,17 +1,36 @@
 # Copyright 2023 Kitti U.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from odoo import _, models
+from odoo import _, api, models, fields
 from odoo.exceptions import ValidationError
 
 
-class AccountMove(models.Model):
+class AccountPayment(models.Model):
     _name = "account.payment"
     _inherit = ["account.payment", "etax.th"]
+
+    has_create_replacement = fields.Boolean(
+        string="Has Create Replacement",
+        copy=False,
+        default=False,
+    )
+
+    def action_open_replacement_wizard(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Create Replacement',
+            'res_model': 'wizard.select.replacement.purpose',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {
+                'default_res_model': self._name,
+            }
+        }
 
     def action_draft(self):
         if self.filtered(
             lambda pay: pay.etax_status in ("success", "processing", "to_process")
-        ):
+        ) and not self.has_create_replacement:
             raise ValidationError(
                 _(
                     "Cannot reset to draft, eTax submission already started "
@@ -32,3 +51,26 @@ class AccountMove(models.Model):
                 return self.reconciled_invoice_ids[0].branch_id.name
         else:
             return False
+
+    def create_replacement_etax(self):
+        """
+        Create replacement receipt eTax
+        """
+        self.ensure_one()
+        if not (self.state == "posted" and self.etax_status == "success"):
+            raise ValidationError(_("Only posted etax payment can have a substitution"))
+        if len(self.reconciled_invoice_ids) > 1:
+            raise ValidationError(_("Multiple reconciled invoices not allowed"))
+        res = self.with_context(include_business_fields=True).copy_data()
+        old_number = self.name
+        res[0]["posted_before"] = self.posted_before
+        res[0]["date"] = self.date
+        res[0]["ref"] = self.ref
+        res[0]["doc_name_template"] = self.doc_name_template.id
+        payment = self.create(res[0])
+        self.has_create_replacement = True
+        self.action_draft()
+        self.action_cancel()
+        self.name = old_number  # Ensure name.
+        return payment
+

--- a/frappe_etax_service/models/account_payment.py
+++ b/frappe_etax_service/models/account_payment.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Kitti U.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from odoo import _, api, models, fields
+from odoo import _, fields, models
 from odoo.exceptions import ValidationError
 
 
@@ -16,20 +16,23 @@ class AccountPayment(models.Model):
     def action_open_replacement_wizard(self):
         self.ensure_one()
         return {
-            'type': 'ir.actions.act_window',
-            'name': 'Create Replacement',
-            'res_model': 'wizard.select.replacement.purpose',
-            'view_mode': 'form',
-            'target': 'new',
-            'context': {
-                'default_res_model': self._name,
-            }
+            "type": "ir.actions.act_window",
+            "name": "Create Replacement",
+            "res_model": "wizard.select.replacement.purpose",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_res_model": self._name,
+            },
         }
 
     def action_draft(self):
-        if self.filtered(
-            lambda pay: pay.etax_status in ("success", "processing", "to_process")
-        ) and not self.has_create_replacement:
+        if (
+            self.filtered(
+                lambda pay: pay.etax_status in ("success", "processing", "to_process")
+            )
+            and not self.has_create_replacement
+        ):
             raise ValidationError(
                 _(
                     "Cannot reset to draft, eTax submission already started "
@@ -72,4 +75,3 @@ class AccountPayment(models.Model):
         self.action_cancel()
         self.name = old_number  # Ensure name.
         return payment
-

--- a/frappe_etax_service/models/etax_th.py
+++ b/frappe_etax_service/models/etax_th.py
@@ -69,6 +69,13 @@ class ETaxTH(models.AbstractModel):
         copy=False,
         help="Currently this field only support invoice and not payment",
     )
+    replaced_receipt_id = fields.Many2one(
+        comodel_name="account.payment",
+        string="Replaced Receipt Payment Document",
+        readonly=True,
+        copy=False,
+        help="This field support replacement payment",
+    )
     is_send_frappe = fields.Boolean(
         copy=False,
     )

--- a/frappe_etax_service/views/account_move_views.xml
+++ b/frappe_etax_service/views/account_move_views.xml
@@ -38,9 +38,9 @@
                     }"
                 />
                 <button
-                    string='Create Replacement e-Tax'
-                    name="frappe_etax_service.action_select_replacement_purpose_view"
-                    type="action"
+                    name="action_open_replacement_wizard"
+                    string="Create Replacement e-Tax"
+                    type="object"
                     attrs="{'invisible': ['|', ('etax_status', '!=', 'success'), ('state', '!=', 'posted')]}"
                 />
             </xpath>

--- a/frappe_etax_service/views/account_move_views.xml
+++ b/frappe_etax_service/views/account_move_views.xml
@@ -45,10 +45,7 @@
                 />
             </xpath>
             <xpath expr="//page[@id='other_tab_entry']" position="after">
-                <page
-                    id="frappe_etax_service"
-                    string="e-Tax Info"
-                >
+                <page id="frappe_etax_service" string="e-Tax Info">
                     <group>
                         <group string="e-Tax">
                             <field

--- a/frappe_etax_service/views/account_payment_views.xml
+++ b/frappe_etax_service/views/account_payment_views.xml
@@ -42,19 +42,18 @@
                     type="object"
                     class="btn-info"
                     attrs="{
-                        'invisible': ['|', '|',
+                        'invisible': ['|',
                             ('etax_status', 'in', ['success']),
                             ('state', 'not in', ('posted')),
-                            ('tax_invoice_ids', '=', [])
                         ]
                     }"
                 />
-                <!-- <button
-                    string='Create Replacement e-Tax'
-                    name="frappe_etax_service.action_select_replacement_purpose_view"
-                    type="action"
+                <button
+                    name="action_open_replacement_wizard"
+                    string="Create Replacement Receipt e-Tax"
+                    type="object"
                     attrs="{'invisible': ['|', ('etax_status', '!=', 'success'), ('state', '!=', 'posted')]}"
-                /> -->
+                />
             </xpath>
             <xpath expr="//sheet/group" position="inside">
                 <group name="etax_info" string="e-Tax">
@@ -91,6 +90,20 @@
                         string="Error message"
                         readonly="1"
                         force_save="1"
+                    />
+                </group>
+                <group string="Additional Information">
+                    <field
+                        name="replaced_receipt_id"
+                        attrs="{'invisible': [('replaced_receipt_id', '=', False)]}"
+                    />
+                    <field
+                        name="create_purpose_code"
+                        attrs="{'required': [('replaced_receipt_id', '!=', False)]}"
+                    />
+                    <field
+                        name="create_purpose"
+                        attrs="{'required': [('replaced_receipt_id', '!=', False)]}"
                     />
                 </group>
             </xpath>

--- a/frappe_etax_service/wizards/wizard_select_replacement_purpose.py
+++ b/frappe_etax_service/wizards/wizard_select_replacement_purpose.py
@@ -20,16 +20,16 @@ class WizardSelectReplacementPurpose(models.TransientModel):
         required=True,
     )
     res_model = fields.Char(
-        string='Resource Model',
-        default=lambda self: self.env.context.get('default_res_model', '')
+        string="Resource Model",
+        default=lambda self: self.env.context.get("default_res_model", ""),
     )
 
     @api.model
     def default_get(self, fields):
         res = super().default_get(fields)
         context = self.env.context
-        if context.get('default_res_model'):
-            res['res_model'] = context.get('default_res_model')
+        if context.get("default_res_model"):
+            res["res_model"] = context.get("default_res_model")
         return res
 
     @api.onchange("purpose_code_id")
@@ -38,10 +38,10 @@ class WizardSelectReplacementPurpose(models.TransientModel):
 
     def create_replacement(self):
         active_ids = self.env.context.get("active_ids", [])
-        if self.res_model == 'account.move':
+        if self.res_model == "account.move":
             move = self.env["account.move"].browse(active_ids)
             invoice_date = move.invoice_date
-        elif self.res_model == 'account.payment':
+        elif self.res_model == "account.payment":
             move = self.env["account.payment"].browse(active_ids)
             invoice_date = move.date
 
@@ -62,9 +62,9 @@ class WizardSelectReplacementPurpose(models.TransientModel):
         replacement.create_purpose_code = self.purpose_code_id.code
         replacement.create_purpose = self.reason
 
-        if self.res_model == 'account.move':
+        if self.res_model == "account.move":
             replacement.replaced_entry_id = move
-        elif self.res_model == 'account.payment':
+        elif self.res_model == "account.payment":
             replacement.replaced_receipt_id = move
 
         return {

--- a/frappe_etax_service/wizards/wizard_select_replacement_purpose.py
+++ b/frappe_etax_service/wizards/wizard_select_replacement_purpose.py
@@ -19,6 +19,18 @@ class WizardSelectReplacementPurpose(models.TransientModel):
     reason = fields.Char(
         required=True,
     )
+    res_model = fields.Char(
+        string='Resource Model',
+        default=lambda self: self.env.context.get('default_res_model', '')
+    )
+
+    @api.model
+    def default_get(self, fields):
+        res = super(WizardSelectReplacementPurpose, self).default_get(fields)
+        context = self.env.context
+        if context.get('default_res_model'):
+            res['res_model'] = context.get('default_res_model')
+        return res
 
     @api.onchange("purpose_code_id")
     def _onchange_purpose_code_id(self):
@@ -26,13 +38,35 @@ class WizardSelectReplacementPurpose(models.TransientModel):
 
     def create_replacement(self):
         active_ids = self.env.context.get("active_ids", [])
-        move = self.env["account.move"].browse(active_ids)
+        if self.res_model == 'account.move':
+            move = self.env["account.move"].browse(active_ids)
+            invoice_date = move.invoice_date
+        elif self.res_model == 'account.payment':
+            move = self.env["account.payment"].browse(active_ids)
+            invoice_date = move.date
+
         move.ensure_one()
-        self._check_replacement_lock_date(move.invoice_date)
+
+        self._check_replacement_lock_date(invoice_date)
+
+        # Create replacement name
+        old_number = move.name
+        suffix = "-R"
+        if suffix in old_number:
+            [number, rev] = old_number.split(suffix)
+            replace_name = f"{number}{suffix}{int(rev) + 1}"
+        else:
+            replace_name = f"{old_number}{suffix}{1}"
         replacement = move.create_replacement_etax()
+        replacement.name = replace_name
         replacement.create_purpose_code = self.purpose_code_id.code
         replacement.create_purpose = self.reason
-        replacement.replaced_entry_id = move
+
+        if self.res_model == 'account.move':
+            replacement.replaced_entry_id = move
+        elif self.res_model == 'account.payment':
+            replacement.replaced_receipt_id = move
+
         return {
             "type": "ir.actions.act_window",
             "views": [(False, "form")],

--- a/frappe_etax_service/wizards/wizard_select_replacement_purpose.py
+++ b/frappe_etax_service/wizards/wizard_select_replacement_purpose.py
@@ -26,7 +26,7 @@ class WizardSelectReplacementPurpose(models.TransientModel):
 
     @api.model
     def default_get(self, fields):
-        res = super(WizardSelectReplacementPurpose, self).default_get(fields)
+        res = super().default_get(fields)
         context = self.env.context
         if context.get('default_res_model'):
             res['res_model'] = context.get('default_res_model')


### PR DESCRIPTION
ปรับให้ระบบ สามารถสร้าง Receipt Replacement ได้ (กรณีออกใบแทน ใบเสร็จรับเงิน หรือ ใบเสร็จรับเงิน/ใบกำกับภาษี)

ซึ่งหากเรียกใช้ฟังชันก์ ระบบจะยกเลิก Receipt ใบเดิม สร้างเอกสารใบใหม่ Status Draft
User จะต้อง post และ reconcile กับ invoice เอง
กรณีใบแทนมี tax เกิดขึ้นตอน reconcile 

หลังจาก reconcile ที่หน้า Payment จะต้องกด server action Update Tax invoice number ด้วย