### PR TITLE
[18.0][FIX] usability_webhooks: test script with api.log

### DIFF
--- a/usability_webhooks/tests/api_log_tester.py
+++ b/usability_webhooks/tests/api_log_tester.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class APILogTester(models.Model):
+    _inherit = "api.log"
+
+    subtype_test_id = fields.Many2one(comodel_name="mail.message.subtype")

--- a/usability_webhooks/tests/test_webhook_utils.py
+++ b/usability_webhooks/tests/test_webhook_utils.py
@@ -1,3 +1,8 @@
+# Copyright 2025 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_test_helper import FakeModelLoader
+
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
@@ -8,76 +13,85 @@ class TestWebhookUtils(TransactionCase):
         super().setUpClass()
         # Initialize test data
         cls.webhook_utils = cls.env["webhook.utils"]
-        cls.partner_model = "res.partner"
+        cls.api_log_model = "api.log"
 
-        # Create test partner
-        cls.test_partner = cls.env.ref("base.res_partner_3")
-        cls.test_partner.write(
+        # Create test log
+        cls.test_log = cls.env["api.log"].create(
             {
-                "name": "Test Partner",
-                "email": "test@example.com",
+                "log_type": "receive",
+                "function_name": "Common Test",
             }
         )
 
+        # Add inherit api.log for test
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+        from .api_log_tester import APILogTester
+
+        cls.loader.update_registry((APILogTester,))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super().tearDownClass()
+
     def test_01_create_data(self):
-        """Test creating a new partner via webhook"""
+        """Test creating a new group via webhook"""
         vals = {
             "payload": {
-                "name": "New Partner",
-                "email": "new@example.com",
+                "log_type": "receive",
+                "function_name": "Test Input",
             }
         }
-        result = self.webhook_utils.create_data(self.partner_model, vals)
+        result = self.webhook_utils.create_data(self.api_log_model, vals)
         self.assertTrue(result["is_success"])
         self.assertTrue(result["result"]["id"])
 
-        # Verify created partner
-        partner = self.env[self.partner_model].browse(result["result"]["id"])
-        self.assertEqual(partner.name, "New Partner")
-        self.assertEqual(partner.email, "new@example.com")
+        # Verify created group
+        group = self.env[self.api_log_model].browse(result["result"]["id"])
+        self.assertEqual(group.function_name, "Test Input")
 
     def test_02_update_data(self):
-        """Test updating existing partner via webhook"""
+        """Test updating existing group via webhook"""
         vals = {
             "search_key": {
-                "id": self.test_partner.id,
+                "id": self.test_log.id,
             },
             "payload": {
-                "name": "Updated Partner",
-                "email": "updated@example.com",
+                "function_name": "Updated Function",
             },
         }
-        result = self.webhook_utils.update_data(self.partner_model, vals)
+        result = self.webhook_utils.update_data(self.api_log_model, vals)
         self.assertTrue(result["is_success"])
 
-        # Verify updated partner
-        self.assertEqual(self.test_partner.name, "Updated Partner")
-        self.assertEqual(self.test_partner.email, "updated@example.com")
+        # Verify updated group
+        self.assertEqual(self.test_log.function_name, "Updated Function")
 
     def test_03_search_data(self):
-        """Test searching partners via webhook"""
+        """Test searching group via webhook"""
         vals = {
             "payload": {
-                "search_field": ["name", "email"],
-                "search_domain": "[('name', '=', 'Test Partner')]",
+                "search_field": ["function_name"],
+                "search_domain": "[('function_name', '=', 'Common Test')]",
                 "limit": 1,
             }
         }
-        result = self.webhook_utils.search_data(self.partner_model, vals)
+        result = self.webhook_utils.search_data(self.api_log_model, vals)
         self.assertTrue(result["is_success"])
         self.assertTrue(result["result"])
-        self.assertEqual(result["result"][0]["name"], "Test Partner")
+        self.assertEqual(result["result"][0]["function_name"], "Common Test")
 
     def test_04_create_with_many2one(self):
         """Test creating record with many2one relation"""
         vals = {
             "payload": {
-                "name": "New Company",
-                "country_id": "Thailand",  # Using name instead of ID
+                "log_type": "receive",
+                "function_name": "Test New Group",
+                "subtype_test_id": "Test New Subtype",  # Using name instead of ID
             },
-            "auto_create": {"country_id": {"name": "Thailand"}},
+            "auto_create": {"subtype_test_id": {"name": "Test New Subtype"}},
         }
-        result = self.webhook_utils.create_data("res.company", vals)
+        result = self.webhook_utils.create_data(self.api_log_model, vals)
         self.assertTrue(result["is_success"])
 
     def test_05_create_with_attachment(self):
@@ -93,13 +107,13 @@ class TestWebhookUtils(TransactionCase):
                 ],
             }
         }
-        result = self.webhook_utils.create_data(self.partner_model, vals)
+        result = self.webhook_utils.create_data(self.api_log_model, vals)
         self.assertTrue(result["is_success"])
 
         # Verify attachment
         attachment = self.env["ir.attachment"].search(
             [
-                ("res_model", "=", self.partner_model),
+                ("res_model", "=", self.api_log_model),
                 ("res_id", "=", result["result"]["id"]),
             ]
         )
@@ -110,14 +124,14 @@ class TestWebhookUtils(TransactionCase):
         """Test calling model function via webhook"""
         vals = {
             "search_key": {
-                "id": self.test_partner.id,
+                "id": self.test_log.id,
             },
             "payload": {
-                "method": "_compute_display_name",
+                "method": "action_call_api",
                 "parameter": {},
             },
         }
-        result = self.webhook_utils.call_function(self.partner_model, vals)
+        result = self.webhook_utils.call_function(self.api_log_model, vals)
         self.assertTrue(result["is_success"])
 
     def test_07_invalid_search_key(self):
@@ -127,5 +141,7 @@ class TestWebhookUtils(TransactionCase):
                 "name": "Test",
             }
         }
-        with self.assertRaises(ValidationError):
-            self.webhook_utils.update_data(self.partner_model, vals)
+        with self.assertRaisesRegex(
+            ValidationError, "Parameter 'search_key' in 'vals' not found!"
+        ):
+            self.webhook_utils.update_data(self.api_log_model, vals)


### PR DESCRIPTION
Change test script usability_webhooks because `res.partner` is required when install account module