### PR TITLE
[18.0][FIX] request_document_expense: test script without taxes

### DIFF
--- a/request_document_expense/tests/test_request_document.py
+++ b/request_document_expense/tests/test_request_document.py
@@ -15,7 +15,8 @@ class TestRequestDocumentExpense(TestExpenseCommon):
         super().setUpClass()
         cls.expense_sheet_model = cls.env["hr.expense.sheet"]
         cls.request_model = cls.env["request.order"]
-        cls.expense = cls.create_expense(cls)
+        # Create expense without taxes
+        cls.expense = cls.create_expense(cls, values={"tax_ids": False})
 
     def test_01_process_request_expense(self):
         # Create request order and line


### PR DESCRIPTION
Fix test script create expense without taxes for support with module l10n_th_account_tax