### PR TITLE
[18.0][FIX] usability_webhooks: fix case auto-added o2m lines in attachment loop

### DIFF
--- a/usability_webhooks/controllers/utils.py
+++ b/usability_webhooks/controllers/utils.py
@@ -56,6 +56,8 @@ class WebhookUtils(models.AbstractModel):
             for line_field, line_data in data_dict.items():
                 if isinstance(line_data, list) and line_field in obj:
                     for i, obj_line in enumerate(obj[line_field]):
+                        if i >= len(line_data):
+                            break
                         line_data_dict = line_data[i]
                         add_attachments(obj_line, line_data_dict, file_attach)
 


### PR DESCRIPTION
Step to test:
1. Implement auto-create line logic inside `create()`, similar to `account.move.line`
2. Call API to create a new line record
3. The system creates:
    - the line from API request
    - an additional auto-created line
4. error `line 59, in add_attachments\n    line_data_dict = line_data[i]\nIndexError: list index out of range\n`