### PR TITLE
[15.0][FIX] hr_expense_cash_basis: fix dupicate tax invoice when group payment

### DIFF
--- a/hr_expense_cash_basis/models/account_partial_reconcile.py
+++ b/hr_expense_cash_basis/models/account_partial_reconcile.py
@@ -27,10 +27,10 @@ class AccountPartialReconcile(models.Model):
 
         moves_to_create = []
         to_reconcile_after = []
+        partial_duplicate_expense = []
         for move_values in tax_cash_basis_values_per_move.values():
             move = move_values["move"]
             pending_cash_basis_lines = []
-            partial_duplicate_expense = []
             for partial_values in move_values["partials"]:
                 partial = partial_values["partial"]
                 if (


### PR DESCRIPTION
แก้ไขกรณี Group payment และ  undue vat อยู่ใน partial reconcile ระหว่าง 2 EX และทำให้เกิด Cash basis ซ้ำ

เช่น
EX 1 มี undue vat 
EX 2 ไม่มี undue vat

เมื่อ group payment ระบบทำการ reconcile โดยแบ่งยอด undue vat ไปยัง EX1 70% EX2 30%
เมื่อวน loop ของ EX 1 ระบบจะสร้าง 1 Cash basis 
เมื่อวน loop ของ EX 2 ระบบจะล้าง partial_duplicate_expense ทำระบบสร้าง Cash basis อีกครั้ง

