### PR TITLE
[15.0][FIX] request_document_expense: skip create expense, if not draft

### DIFF
--- a/request_document_expense/models/request_document.py
+++ b/request_document_expense/models/request_document.py
@@ -43,6 +43,10 @@ class RequestDocument(models.Model):
     def _create_expense(self):
         self.ensure_one()
         sheet = self.expense_sheet_ids.with_context(allow_edit=1)
+        # Make sure sheet must state draft
+        if sheet.state != "draft":
+            return
+
         # Change to submit
         sheet.action_submit_sheet()
         # Check config


### PR DESCRIPTION
Step to reproduce:
1. Use `base_tier_validation_server_action` to auto validate request expense when approval validated
2. It will call _create_expense 2 times

This PR fixed make sure it will call 1 time (will error if we install budget_control_request_document_expense)