### PR TITLE
[18.0][IMP] frappe_etax_service: hide eTax UI when connection is not configured

### DIFF
--- a/frappe_etax_service/models/account_move.py
+++ b/frappe_etax_service/models/account_move.py
@@ -33,6 +33,20 @@ class AccountMove(models.Model):
     is_etax_configured = fields.Boolean(
         related="company_id.is_etax_configured",
     )
+    enable_etax = fields.Boolean(
+        compute="_compute_enable_etax",
+        store=True,
+    )
+
+    @api.depends("move_type", "etax_status", "state", "is_etax_configured")
+    def _compute_enable_etax(self):
+        for rec in self:
+            rec.enable_etax = (
+                rec.move_type in ("out_invoice", "out_refund", "out_invoice_debit")
+                and rec.etax_status not in ("success", "processing")
+                and rec.state == "posted"
+                and rec.company_id.is_etax_configured
+            )
 
     @api.onchange("is_credit_payment_entry", "create_purpose")
     def _onchange_ref(self):

--- a/frappe_etax_service/models/account_move.py
+++ b/frappe_etax_service/models/account_move.py
@@ -30,6 +30,9 @@ class AccountMove(models.Model):
         copy=False,
         help="Currently this field only support invoice and not payment",
     )
+    is_etax_configured = fields.Boolean(
+        related="company_id.is_etax_configured",
+    )
 
     @api.onchange("is_credit_payment_entry", "create_purpose")
     def _onchange_ref(self):

--- a/frappe_etax_service/models/account_payment.py
+++ b/frappe_etax_service/models/account_payment.py
@@ -23,6 +23,9 @@ class AccountPayment(models.Model):
         copy=False,
         help="This field support replacement payment",
     )
+    is_etax_configured = fields.Boolean(
+        related="company_id.is_etax_configured",
+    )
 
     def _hook_update_data(self, code_api, result):
         res = super()._hook_update_data(code_api, result)

--- a/frappe_etax_service/models/account_payment.py
+++ b/frappe_etax_service/models/account_payment.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Kitti U.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -26,6 +26,19 @@ class AccountPayment(models.Model):
     is_etax_configured = fields.Boolean(
         related="company_id.is_etax_configured",
     )
+    enable_etax = fields.Boolean(
+        compute="_compute_enable_etax",
+        store=True,
+    )
+
+    @api.depends("etax_status", "state", "is_etax_configured")
+    def _compute_enable_etax(self):
+        for rec in self:
+            rec.enable_etax = (
+                rec.etax_status not in ("success", "processing")
+                and rec.state == "paid"
+                and rec.company_id.is_etax_configured
+            )
 
     def _hook_update_data(self, code_api, result):
         res = super()._hook_update_data(code_api, result)

--- a/frappe_etax_service/models/res_company.py
+++ b/frappe_etax_service/models/res_company.py
@@ -11,3 +11,6 @@ class ResCompany(models.Model):
     frappe_auth_token = fields.Char()
     is_send_etax_email = fields.Boolean(string="Send Email")
     replacement_lock_date = fields.Integer()
+    is_etax_configured = fields.Boolean(
+        string="Enable e-Tax",
+    )

--- a/frappe_etax_service/models/res_config_settings.py
+++ b/frappe_etax_service/models/res_config_settings.py
@@ -24,6 +24,10 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.replacement_lock_date",
         readonly=False,
     )
+    is_etax_configured = fields.Boolean(
+        related="company_id.is_etax_configured",
+        readonly=False,
+    )
 
     @api.onchange("replacement_lock_date")
     def _onchange_replacement_lock_date(self):

--- a/frappe_etax_service/views/account_move_views.xml
+++ b/frappe_etax_service/views/account_move_views.xml
@@ -69,7 +69,7 @@
                     name="button_etax_invoices"
                     type="object"
                     class="btn-info"
-                    invisible="move_type not in ('out_invoice','out_refund','out_invoice_debit') or etax_status in ['success', 'processing'] or state != 'posted'"
+                    invisible="move_type not in ('out_invoice','out_refund','out_invoice_debit') or etax_status in ['success', 'processing'] or state != 'posted' or not is_etax_configured"
                 />
                 <button
                     name="action_open_replacement_wizard"
@@ -79,7 +79,11 @@
                 />
             </xpath>
             <xpath expr="//page[@id='other_tab_entry']" position="after">
-                <page id="frappe_etax_service" string="e-Tax Info">
+                <page
+                    id="frappe_etax_service"
+                    string="e-Tax Info"
+                    invisible="not is_etax_configured"
+                >
                     <group>
                         <group string="e-Tax">
                             <field

--- a/frappe_etax_service/views/account_move_views.xml
+++ b/frappe_etax_service/views/account_move_views.xml
@@ -69,7 +69,7 @@
                     name="button_etax_invoices"
                     type="object"
                     class="btn-info"
-                    invisible="move_type not in ('out_invoice','out_refund','out_invoice_debit') or etax_status in ['success', 'processing'] or state != 'posted' or not is_etax_configured"
+                    invisible="not enable_etax"
                 />
                 <button
                     name="action_open_replacement_wizard"

--- a/frappe_etax_service/views/account_payment_views.xml
+++ b/frappe_etax_service/views/account_payment_views.xml
@@ -57,7 +57,7 @@
                     name="button_etax_invoices"
                     type="object"
                     class="btn-info"
-                    invisible="etax_status in ['success', 'processing'] or state != 'paid' or not is_etax_configured"
+                    invisible="not enable_etax"
                 />
                 <button
                     name="action_open_replacement_wizard"

--- a/frappe_etax_service/views/account_payment_views.xml
+++ b/frappe_etax_service/views/account_payment_views.xml
@@ -57,7 +57,7 @@
                     name="button_etax_invoices"
                     type="object"
                     class="btn-info"
-                    invisible="etax_status in ['success', 'processing'] or state != 'paid'"
+                    invisible="etax_status in ['success', 'processing'] or state != 'paid' or not is_etax_configured"
                 />
                 <button
                     name="action_open_replacement_wizard"
@@ -78,7 +78,11 @@
                 </button>
             </xpath>
             <xpath expr="//group[@name='main_group']" position="after">
-                <group name="etax_info" string="e-Tax">
+                <group
+                    name="etax_info"
+                    string="e-Tax"
+                    invisible="not is_etax_configured"
+                >
                     <group>
                         <field name="etax_doctype_id" string="Doctype" readonly="1" />
                         <field

--- a/frappe_etax_service/views/res_config_settings.xml
+++ b/frappe_etax_service/views/res_config_settings.xml
@@ -12,36 +12,44 @@
             >
                 <block title="Ecosoft e-Tax Services" id="ecosoft_etax_services">
                     <setting
-                        id="frappe_server_url"
-                        help="URL of the Frappe e-Tax Service."
+                        id="is_etax_configured"
+                        help="Enable e-Tax integration for this company."
                     >
-                        <field
-                            name="frappe_server_url"
-                            placeholder="Paste your frappe server URL"
-                        />
+                        <field name="is_etax_configured" />
                     </setting>
-                    <setting
-                        id="frappe_auth_token"
-                        help="Authentication token for Frappe e-Tax Service. Format: [api_key]:[api_secret]"
-                    >
-                        <field
-                            name="frappe_auth_token"
-                            password="True"
-                            placeholder="Paste your frappe token"
-                        />
-                    </setting>
-                    <setting
-                        id="frappe_send_email"
-                        help="Allow to send an email to partner after sign etax."
-                    >
-                        <field name="is_send_etax_email" />
-                    </setting>
-                    <setting
-                        id="frappe_replacement_lock_date"
-                        help="e-Tax Replacement not allowed after this date of next invoice month. For example, if replace lock date is 10 and invoice date is 20/11/2000, replacement e-Tax is not allowed after 10/12/2000."
-                    >
-                        <field name="replacement_lock_date" />
-                    </setting>
+                    <div invisible="not is_etax_configured">
+                        <setting
+                            id="frappe_server_url"
+                            help="URL of the Frappe e-Tax Service."
+                        >
+                            <field
+                                name="frappe_server_url"
+                                placeholder="Paste your frappe server URL"
+                            />
+                        </setting>
+                        <setting
+                            id="frappe_auth_token"
+                            help="Authentication token for Frappe e-Tax Service. Format: [api_key]:[api_secret]"
+                        >
+                            <field
+                                name="frappe_auth_token"
+                                password="True"
+                                placeholder="Paste your frappe token"
+                            />
+                        </setting>
+                        <setting
+                            id="frappe_send_email"
+                            help="Allow to send an email to partner after sign etax."
+                        >
+                            <field name="is_send_etax_email" />
+                        </setting>
+                        <setting
+                            id="frappe_replacement_lock_date"
+                            help="e-Tax Replacement not allowed after this date of next invoice month. For example, if replace lock date is 10 and invoice date is 20/11/2000, replacement e-Tax is not allowed after 10/12/2000."
+                        >
+                            <field name="replacement_lock_date" />
+                        </setting>
+                    </div>
                 </block>
             </xpath>
         </field>

--- a/frappe_etax_service/wizards/account_debit_note.py
+++ b/frappe_etax_service/wizards/account_debit_note.py
@@ -30,6 +30,10 @@ class AccountDebitNote(models.TransientModel):
 
     @api.depends("move_ids")
     def _compute_debit_note_doctype_code_ids(self):
+        if self.move_ids and not any(self.move_ids.mapped("is_etax_configured")):
+            for rec in self:
+                rec.debit_note_doctype_code_ids = False
+            return
         codes = (
             self.env["etax.doctype"]
             .search([("move_type", "=", "out_invoice_debit")])

--- a/frappe_etax_service/wizards/account_move_reversal.py
+++ b/frappe_etax_service/wizards/account_move_reversal.py
@@ -30,6 +30,10 @@ class AccountMoveReversal(models.TransientModel):
 
     @api.depends("move_ids")
     def _compute_credit_note_doctype_code_ids(self):
+        if self.move_ids and not any(self.move_ids.mapped("is_etax_configured")):
+            for rec in self:
+                rec.credit_note_doctype_code_ids = False
+            return
         codes = (
             self.env["etax.doctype"]
             .search([("move_type", "=", "out_refund")])


### PR DESCRIPTION
**Problem**
เมื่อติดตั้ง `frappe_etax_service` โดยยังไม่ได้ config `frappe_server_url` และ `frappe_auth_token`
ระบบแสดงปุ่ม e-Tax Invoice, tab e-Tax Info, group e-Tax บนหน้า Invoice/Payment
และ Settings แสดงฟิลด์ config eTax ตลอดเวลา ทำให้ผู้ใช้สับสน

**Solution**
เพิ่ม stored Boolean `is_etax_configured` (Enable e-Tax) บน `res.company` ใช้เป็น gate ควบคุม:
- Settings: ฟิลด์ `frappe_server_url`, `frappe_auth_token`, etc. จะแสดงเมื่อติ๊ก
- Invoice / Payment: ปุ่ม e-Tax, tab e-Tax Info, group e-Tax ซ่อนเมื่อยังไม่ได้ติ๊ก
- Credit/Debit Note Wizard: ไม่เสียเวลา query `etax.doctype` เมื่อยังไม่ได้เปิดใช้ eTax