### PR TITLE
[15.0][FIX] account_move_reconcile_no_cancel: Allow credit note creation via 'refund' method on reconciled invoices

### DIFF
--- a/account_move_reconcile_no_cancel/wizard/account_move_reversal.py
+++ b/account_move_reconcile_no_cancel/wizard/account_move_reversal.py
@@ -10,7 +10,8 @@ class AccountMoveReversal(models.TransientModel):
     def reverse_moves(self):
         self.ensure_one()
         moves = self.move_ids
-        moves._check_move_reconciled(action="reset to draft / reverse")
+        if self.refund_method != "refund":
+            moves._check_move_reconciled(action="reset to draft / reverse")
         res = super().reverse_moves()
         # Overwite payment state to reversed
         moves.with_context(bypass_lockdate=1).write({"payment_state": "reversed"})


### PR DESCRIPTION
ปัญหา (Problem)
เมื่อสร้าง Credit Note (Add Credit Note) จาก Invoice ที่นำส่ง e-Tax และมีสถานะ paid แล้ว จะเกิด ValidationError:

"You cannot reset to draft / reverse reconciled entries."

ทำให้ไม่สามารถสร้าง Customer Credit Note จาก invoice ที่ชำระเงินแล้วได้ และไม่สามารถ Manual สร้างได้เนื่องไม่มีอ้างอิงไปยัง Invoice เพื่อนำส่ง e-Tax

การแก้ไข
-  ตรวจสอบ refund_method ว่าเป็น refund หรือไม่หากเป็น refund ให้ reverse ได้ตามปกติ 

