### PR TITLE
[18.0][IMP] base_print_wizard: add qty copy and type

### DIFF
--- a/base_print_wizard/wizard/base_print_wizard.py
+++ b/base_print_wizard/wizard/base_print_wizard.py
@@ -23,6 +23,18 @@ class BasePrintWizard(models.TransientModel):
         default=lambda self: self._get_doctype_default(),
         required=True,
     )
+    copy_qty = fields.Integer(
+        string="Copies",
+        default=1,
+        required=True,
+    )
+    copy_type = fields.Selection(
+        selection=[
+            ("original", "Original"),
+            ("copy", "Copy"),
+        ],
+        string="Type",
+    )
 
     @api.depends("active_model")
     def _compute_available_doctype_ids(self):
@@ -66,7 +78,18 @@ class BasePrintWizard(models.TransientModel):
         objs = self.env[model].browse(active_ids)
         return objs
 
+    def _get_report_context(self):
+        """Return extra context dict forwarded to the report action.
+        Override to add module-specific keys.
+        """
+        return {
+            "copy_qty": self.copy_qty,
+            "copy_type": self.copy_type,
+        }
+
     def action_print(self):
         self.ensure_one()
         objs = self._get_action_report()
-        return self.doctype.report_action(objs)
+        return self.doctype.with_context(**self._get_report_context()).report_action(
+            objs
+        )

--- a/base_print_wizard/wizard/base_print_wizard_view.xml
+++ b/base_print_wizard/wizard/base_print_wizard_view.xml
@@ -15,7 +15,10 @@
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
                         </group>
-                        <group />
+                        <group>
+                            <field name="copy_qty" />
+                            <field name="copy_type" />
+                        </group>
                     </group>
                     <footer>
                         <button


### PR DESCRIPTION
This PR implement common copy or type on wizard
<img width="1474" height="373" alt="selection_467" src="https://github.com/user-attachments/assets/44b70f8f-36d2-4c87-bc74-ebcdbfe4d7dd" />


How to use:
if other report need to used it. You can implement add context

Example:

```
<template id="report_invoice">
    <t t-call="web.html_container">
        <t t-set="copy_qty" t-value="env.context.get('copy_qty', 1) or 1" />       ----> Add here
        <t t-set="copy_type" t-value="env.context.get('copy_type')" />             ----> Add here
        <t t-foreach="range(max(copy_qty, 1))" t-as="copy_index">
            <t t-foreach="docs" t-as="doc">
                <t t-call="account.report_invoice_document" t-lang="doc.partner_id.lang">
                    <t t-set="copy_label">
                        <t t-if="copy_type == 'original'">Original</t>
                        <t t-elif="copy_type == 'copy'">Copy</t>
                    </t>
                </t>
            </t>
        </t>
    </t>
</template>
```