### PR TITLE
[15.0][FIX] usability_webhooks: prevent JSON serialization error for date fields

### DIFF
--- a/usability_webhooks/controllers/main.py
+++ b/usability_webhooks/controllers/main.py
@@ -9,6 +9,7 @@ from werkzeug.exceptions import BadRequest
 
 from odoo import http
 from odoo.http import request
+from odoo.tools import date_utils
 
 
 class WebhookController(http.Controller):
@@ -55,7 +56,10 @@ class WebhookController(http.Controller):
                     "state": state,
                 }
             )
-            log._save_payload(data_str, json.dumps(res, ensure_ascii=False))
+            log._save_payload(
+                data_str,
+                json.dumps(res, ensure_ascii=False, default=date_utils.json_default),
+            )
         self._link_callback_url(model, vals, res, log)
         return res
 


### PR DESCRIPTION
## Summary

Fixes a `TypeError: Object of type date is not JSON serializable` that occurred when creating API logs in the `search_data` endpoint.

The issue was caused by `json.dumps()` attempting to serialize `datetime.date` and `datetime.datetime` objects returned in the response payload.

## Changes

* Import `date_utils` from Odoo.
* Use `date_utils.json_default` as the `default` serializer for `json.dumps()`.
* Preserve Odoo's standard ISO date/datetime serialization format.

## Example payload

path = `/api/search_data`
```
payload
{
  "params": {
    "model": <model>,
    "vals": {
      "payload": {
        "search_field": [
          "date"
        ],
        "search_domain": "[]",
      }
    }
  }
}
```